### PR TITLE
Migrate to parent POM version 0.11.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.5</version>
+		<version>4.0.13</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
-		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.10.1</version>
+		<artifactId>repository-parent</artifactId>
+		<version>0.11.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator.editors-commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
 		<version>0.10.1</version>
+		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator.editors-commons</groupId>
 	<artifactId>parent</artifactId>	


### PR DESCRIPTION
- Add empty `<relativePath/>` to the parent POM to avoid Maven warnings about mismatched parent resolution.
- Update Tycho version in `.mvn/extensions.xml` to `4.0.13`.
- Migrate from parent POM `eclipse-parent-updatesite` version `0.10.1` to `repository-parent` version `0.11.0`.